### PR TITLE
"contentIsHTML": false

### DIFF
--- a/General/redhat-machines-report-they-are-not-registered-to-rhn-when-running-yum.md
+++ b/General/redhat-machines-report-they-are-not-registered-to-rhn-when-running-yum.md
@@ -3,7 +3,7 @@
   "date": "11-25-2014",
   "author": "James Morris",
   "attachments": [],
-  "contentIsHTML": true
+  "contentIsHTML": false
 }}}
 
 ###Red Hat Update Infrastructure


### PR DESCRIPTION
Set "contentIsHTML": false to properly reflect the markdown for "RedHat machines report they are not registered to RHN when running 'yum'"