### PR TITLE
Updated Troubleshooting Failed Managed Blueprint

### DIFF
--- a/Managed Services/troubleshooting-a-failed-managed-services-blueprint.md
+++ b/Managed Services/troubleshooting-a-failed-managed-services-blueprint.md
@@ -6,7 +6,9 @@
   "contentIsHTML": true
 }}}
 
-<p>If a Managed Services Blueprint does not complete as expected, please follow these steps to expedite troubleshooting.</p>
+<p>If a Managed Services Blueprint does not complete as expected, please note the OS and the time the Blueprint was attempted. RHEL Managed Services Blueprints will fail from 9am to 10am UTC as a result of regular maintenance in our managed services infrastructure. Please wait one hour before attempting again.</p>
+
+<p>If that is not the issue, follow these steps to expedite troubleshooting.</p>
 <p><strong>1. From within the Control Portal, hover over the green bar at the top of the page.</strong>
 </p>
 <p><img src="https://t3n.zendesk.com/attachments/token/U8DbQ8GQAPbqUUC5iz66CKzfe/?name=Menu.png" alt="Menu.png" />


### PR DESCRIPTION
Added information to explain why Make managed RHEL BPs will fail the
same hour out of every week.