### PR TITLE
Update installing-the-af-cli-tool-on-mac-os-x.md- change Ruby version from 2.1 to 2.0

### DIFF
--- a/AppFog/Legacy Version 1/installing-the-af-cli-tool-on-mac-os-x.md
+++ b/AppFog/Legacy Version 1/installing-the-af-cli-tool-on-mac-os-x.md
@@ -6,7 +6,7 @@
   "contentIsHTML": true
 }}}
 
-<p>We recommend using version 2.1 or older as some users have reported issues with Ruby 2.2 compiling.</p>
+<p>We recommend using version 2.0 or older as some users have reported issues with Ruby 2.2 compiling.</p>
 <pre><code>$ gem install af
 </code></pre>
 <ul>


### PR DESCRIPTION
Updated to recommend using Ruby version 2.0 instead of 2.1