### PR TITLE
Adding KB Article for CloudFlare SSL Termination

### DIFF
--- a/WordPress/wordpress-cloudflare-SSL-configuration.md
+++ b/WordPress/wordpress-cloudflare-SSL-configuration.md
@@ -7,22 +7,27 @@
 }}}
 ### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview:
 
-There is currently no automated method for adding SSL termination for a WordPress site in CenturyLink Cloud's WordPress. There are multiple methods that could be used to terminate SSL for an existing WordPress site in CenturyLink Cloud WordPress site. This method covers using CloudFlare CDN's SSL Termination.
+There are multiple methods that could be used to terminate SSL for an existing CenturyLink Cloud WordPress site. This method covers using CloudFlare CDN's SSL Termination.
 
-### This migration path assumes the following:
+### This article assumes the following:
 
 * Working knowledge of basic WordPress functionality
-* Working knowledge of how to [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-)
 
 ### Prerequisites:
 
 1. A CenturyLink WordPress site
-2. A Custom FQDN added to your WordPress Site.
-3. Your Custom FQDN referencing your website "wordpress.ctl.io" URL4.	An existing [CloudFlare] (https://www.cloudflare.com/) account
-## CloudFlare Settings Supported* SSL (with SPDY) = Full, FLexible, or Off (Strict is not currently supported)
+2. A Custom Fully Qualified Domain Name (FQDN) added to your WordPress Site.
+3. An existing [CloudFlare] (https://www.cloudflare.com/) account 
+4. Your customer site name must be configured for use with CloudFlare.
+## CloudFlare Settings SupportedFollowing the [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-) Knowledge Base Article, these are the settings CenturyLink WordPress suports.
+
+* SSL (with SPDY)						= Full, FLexible, or Off (Strict is not currently supported)
 * HTTP Strict Transport Security (HSTS)
  * Max Age Header (max-age)			= Any Setting
  * Apply HSTS policy to subdomains	= On or Off
  * Preload								= On or Off
  * No-Sniff Header						= On or Off
 * Authenticated Origin Pulls			= On or Off
+
+Aditional [SSL related information] (https://support.cloudflare.com/hc/en-us/categories/200276247) on CloudFlare
+

--- a/WordPress/wordpress-cloudflare-SSL-configuration.md
+++ b/WordPress/wordpress-cloudflare-SSL-configuration.md
@@ -1,0 +1,28 @@
+{{{
+  "title": "WordPress Cloud Flare SSL Termination",
+  "date": "08-25-2015",
+  "author": "Earl Herman",
+  "attachments": [],
+  "contentIsHTML": false
+}}}
+### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview:
+
+There is currently no automated method for adding SSL termination for a WordPress site in CenturyLink Cloud's WordPress. There are multiple methods that could be used to terminate SSL for an existing WordPress site in CenturyLink Cloud WordPress site. This method covers using CloudFlare CDN's SSL Termination.
+
+### This migration path assumes the following:
+
+* Working knowledge of basic WordPress functionality
+* Working knowledge of how to [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-)
+
+### Prerequisites:
+
+1. A CenturyLink WordPress site
+2. A Custom FQDN added to your WordPress Site.
+3. Your Custom FQDN referencing your website "wordpress.ctl.io" URL4.	An existing [CloudFlare] (https://www.cloudflare.com/) account
+## CloudFlare Settings Supported* SSL (with SPDY) = Full, FLexible, or Off (Strict is not currently supported)
+* HTTP Strict Transport Security (HSTS)
+ * Max Age Header (max-age)			= Any Setting
+ * Apply HSTS policy to subdomains	= On or Off
+ * Preload								= On or Off
+ * No-Sniff Header						= On or Off
+* Authenticated Origin Pulls			= On or Off

--- a/WordPress/wordpress-cloudflare-SSL-configuration.md
+++ b/WordPress/wordpress-cloudflare-SSL-configuration.md
@@ -19,7 +19,7 @@ There are multiple methods that could be used to terminate SSL for an existing C
 2. A Custom Fully Qualified Domain Name (FQDN) added to your WordPress Site.
 3. An existing [CloudFlare] (https://www.cloudflare.com/) account 
 4. Your customer site name must be configured for use with CloudFlare.
-## CloudFlare Settings SupportedFollowing the [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-) Knowledge Base Article, these are the settings CenturyLink WordPress suports.
+### CloudFlare Settings SupportedFollowing the [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-) Knowledge Base Article, these are the settings CenturyLink WordPress suports.
 
 * SSL (with SPDY)						= Full, FLexible, or Off (Strict is not currently supported)
 * HTTP Strict Transport Security (HSTS)

--- a/WordPress/wordpress-cloudflare-SSL-configuration.md
+++ b/WordPress/wordpress-cloudflare-SSL-configuration.md
@@ -5,7 +5,7 @@
   "attachments": [],
   "contentIsHTML": false
 }}}
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview:
+### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.### Overview:
 
 There are multiple methods that could be used to terminate SSL for an existing CenturyLink Cloud WordPress site. This method covers using CloudFlare CDN's SSL Termination.
 


### PR DESCRIPTION
This addition is to show how a client can use CloudFlare for SSL Termination for custom hostnames.