### PR TITLE
Documenting WordPress deployment rollback feature for customers

### DIFF
--- a/WordPress/getting-started-with-wordpress-as-a-service.md
+++ b/WordPress/getting-started-with-wordpress-as-a-service.md
@@ -100,3 +100,7 @@ A: You [push your committed changes with git](wordPress-site-updates-with-git.md
 **Q: How do I get a local development environment that's easy to work with?**
 
 A: [vagrant up](wordpress-local-development.md)!
+
+**Q: I accidentally pushed a bad commit to my CenturyLink Git Hosting repository!**
+
+A: You can [roll back](wordpress-deployment-rollback.md) a bad push.

--- a/WordPress/wordpress-deployment-rollback.md
+++ b/WordPress/wordpress-deployment-rollback.md
@@ -1,0 +1,63 @@
+{{{
+  "title": "Rolling Back WordPress Sites",
+  "date": "10-08-2015",
+  "author": "Matt Wittmann",
+  "attachments": [],
+  "contentIsHTML": false
+}}}
+
+### IMPORTANT NOTE
+
+CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
+and is not intended for production usage.
+
+During the Limited Beta there is no production Service Level Agreement.
+
+### Overview
+
+Rollback is the complement to [site update with git](wordpress-site-updates-with-git.md).
+It is important to []test plug-in and theme changes locally](wordpress-local-development.md)
+with Vagrant, but if a bad change has been pushed to the live site, it is possible
+to roll back without dealing with git commit history and reverts.
+
+The rollback feature is intended as a quick fix until the site's git repository is
+fixed. After a rollback is performed, further rollbacks are disabled until the next
+push to CenturyLink Git Hosting; in other words, it is **not** possible to roll back
+the rollback. The code in the CenturyLink Git Hosting repository is not modified.
+
+### Prerequisites
+
+* A WordPress site has been created using CenturyLink WordPress-as-a-Service.
+* A change to the site has been committed and pushed to CenturyLink Git Hosting.
+* The change is undesired and needs to be rolled back.
+
+### Rollback Process
+
+1. [Log in](https://wordpress.ctl.io/) to CenturyLink WordPress-as-a-Service.
+2. Find the site that needs to be rolled back in the list of sites.
+3. The "Roll Back" button is on the right side of the row. If no "Roll Back" button
+   is visible for a given site, that site cannot be rolled back—either because it is
+   a newly created site with no changes or because it has already been rolled back
+   without further git pushes.
+4. Click the "Roll Back" button. You will be prompted to confirm your choice.
+5. The rollback process is initiated. This can take a couple of minutes. As with
+   the initial blue/green deployment of updates from git, there may be a brief window
+   when your site resolves to both the erroneous version and the version you are
+   rolling back to.
+6. The rollback process can take a few minutes to complete. If your site is still
+   not rolled back after several minutes, you may consider opening a support ticket.
+   Note that rollback will go two pushes back only. If you have committed and pushed
+   several times without verifying your changes, the only way to recover will be
+   manually reverting all the bad commits in your git history.
+
+### After the Rollback
+
+The rollback takes a site two git pushes back. If this version is also bad, a [git
+revert](http://git-scm.com/docs/git-revert) will need to be performed. Performing a
+git revert is also useful to fix the last bad push in the git repository.
+Regardless, it is important to bring the `refs/HEAD/master` of the repository
+back to a non-broken state. Once the fixing commits are pushed back up,
+the normal blue/green deployment process of the site update will begin.
+
+**Because of the rollback, until further commits are pushed to the site's repository,
+the git repository will no longer be synchronized with the live site!**

--- a/WordPress/wordpress-deployment-rollback.md
+++ b/WordPress/wordpress-deployment-rollback.md
@@ -15,7 +15,7 @@ During the Limited Beta there is no production Service Level Agreement.
 
 ### Overview
 
-Rollback is the complement to [site update with git](wordpress-site-updates-with-git.md).
+Rollback is the complement to [site update with git](wordPress-site-updates-with-git.md).
 It is important to []test plug-in and theme changes locally](wordpress-local-development.md)
 with Vagrant, but if a bad change has been pushed to the live site, it is possible
 to roll back without dealing with git commit history and reverts.

--- a/WordPress/wordpress-deployment-rollback.md
+++ b/WordPress/wordpress-deployment-rollback.md
@@ -16,7 +16,7 @@ During the Limited Beta there is no production Service Level Agreement.
 ### Overview
 
 Rollback is the complement to [site update with git](wordPress-site-updates-with-git.md).
-It is important to []test plug-in and theme changes locally](wordpress-local-development.md)
+It is important to [test plug-in and theme changes locally](wordpress-local-development.md)
 with Vagrant, but if a bad change has been pushed to the live site, it is possible
 to roll back without dealing with git commit history and reverts.
 


### PR DESCRIPTION
We are adding the ability for customers to quickly roll back pushes of bad changes to their WordPress sites.