### PR TITLE
Made a doc sticky, added MySQL export option, added link.

### DIFF
--- a/AFv1/export-services-and-third-party-alternatives.md
+++ b/AFv1/export-services-and-third-party-alternatives.md
@@ -29,7 +29,22 @@ The export utility in AppFog v1 is subject to timeout for databases larger than 
 2: mysql
 3: mysqldump
 </pre>
-2. Export a MySQL database using phpMyAdmin:
+2. Export a MySQL database using the `export-service` command:
+  * Use `export-service` to generate a dump URI.
+  * Download the file from the URL.
+  * Give the file the ZIP file extension.
+  * Decompress the ZIP and navigate to the content folder in your current directory.
+  * Decompress the SQL file from the Gunzip (GZ) file.
+  * An example is below:
+<pre>af export-service \<service_name\>
+mkdir \<service_name\>
+cd \<service_name\>
+wget -c -O \<service_name\>.zip \<URL_provided_by_export-service_command\>
+unzip \<service_name\>.zip
+cd content
+gunzip *.gz
+</pre>
+3. Export a MySQL database using phpMyAdmin:
   * Deploy a [phpMyAdmin on AppFog](phpmyadmin-on-appfog.md) jumpstart app.
   * Use the phpMyAdmin export utility.
   * For large databases that still experience timeouts you can export the database in chunks, selecting single or multiple tables at a time.

--- a/AFv1/how-to-migrate-an-application.md
+++ b/AFv1/how-to-migrate-an-application.md
@@ -25,3 +25,4 @@ Users may export their app code either from the command line or the web console:
 * [Enable AppFog in the Control Portal](../AppFog/getting-started-with-appfog.md/#enable-appfog-in-control-portal)
 * [Install the Cloud Foundry CLI tool](../AppFog/login-using-cf-cli.md)
 * [Deploying an Application](../AppFog/deploy-an-application.md)
+* [Setup Custom Domain for Application](../AppFog/setup-custom-domain-for-appfog-app.md/)

--- a/AFv1/migrating-legacy-apps-to-the-cloud-with-paas.md
+++ b/AFv1/migrating-legacy-apps-to-the-cloud-with-paas.md
@@ -3,7 +3,8 @@
   "date": "1-20-2015",
   "author": "Chris Sterling",
   "attachments": [],
-  "contentIsHTML": false
+  "contentIsHTML": false,
+  "sticky": true
 }}}
 
 ### IMPORTANT


### PR DESCRIPTION
I made the document AFv1/migrating-legacy-apps-to-the-cloud-with-paas.md sticky, I added an option to get a MySQL database dump using the `export-service` command using the **af** gem, and I added a link to AppFog/setup-custom-domain-for-appfog-app.md in AFv1/how-to-migrate-an-application.md.