### PR TITLE
Change Product Name

### DIFF
--- a/WordPress/cherry_framework.md
+++ b/WordPress/cherry_framework.md
@@ -10,14 +10,14 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
 
 During the Limited Beta there is no production Service Level Agreement.
 
 ### Overview
 The [Cherry Framework for WordPress](http://www.cherryframework.com/) is a free framework that can use WordPress themes from Template Monster that are made to use with the Cherry Framework. 
 
-Most of what you need to know is already covered in the [quick start guide on Template Monster](http://www.templatemonster.com/help/quick-start-guide/wordpress-themes/master/index_en.html#introduction).  In this KB article, we will cover how to install and setup Cherry Framework on the [CenturyLink Cloud WordPress](https://www.ctl.io/wordpress) platform so that you can take advantage of it.
+Most of what you need to know is already covered in the [quick start guide on Template Monster](http://www.templatemonster.com/help/quick-start-guide/wordpress-themes/master/index_en.html#introduction).  In this KB article, we will cover how to install and setup Cherry Framework on the [CenturyLink WordPress](https://www.ctl.io/wordpress) hosting platform so that you can take advantage of it.
 
 
 ### Cherry Framework Features

--- a/WordPress/getting-started-with-wordpress-as-a-service.md
+++ b/WordPress/getting-started-with-wordpress-as-a-service.md
@@ -1,5 +1,5 @@
 {{{
-  "title": "Getting Started with WordPress as a Service",
+  "title": "Getting Started with CenturyLink WordPress Hosting",
   "date": "10-15-2015",
   "author": "Bill Burge, Andy Watson",
   "attachments": [],
@@ -8,15 +8,16 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
 
 ## Overview
+Today nearly 25% of the sites on the internet are WordPress sites. WordPress is an open source project that started out as just a blogging system, but is now known as a content management system that is unlimited in ways that it can be used. There is also thousands of plugins, themes and widgets that help extend and add to the functionality that already comes with WordPress.
 
-[WordPress](http://www.wordpress.org) is a free open-source blogging tool and content management system (CMS) based on PHP and MySQL.
+In addition to all that WordPress has to offer, there is an extensive and helpful community of WordPress users around the world. Questions and answers can be found in [support forums](https://wordpress.org/support/), [mailing lists](https://codex.wordpress.org/Mailing_Lists), [WordCamps](https://central.wordcamp.org/) and if that is not enough, thousands of video presentations exists and are being added to on [wordpress.tv](http://wordpress.tv/) to help everyone from the beginner to the expert.
 
-CenturyLink Cloud's WordPress as a Service is a secure, Enterprise class, cloud-based WordPress installation for enterprise level customers.
+CenturyLink's WordPress Hosting platform hosts secure, enterprise class, cloud-based WordPress sites.
 
 ### Prerequisites
 
@@ -48,7 +49,7 @@ CenturyLink Cloud's WordPress as a Service is a secure, Enterprise class, cloud-
 
   ![](../images/wp_getting_started/wp_getting_started_6.png)
 
-7. You will also receive an email from CenturyLink WordPress's Git Repository asking for confirmation. Click Confirm your account.
+7. You will also receive an email from the CenturyLink Git Repository asking for confirmation. Click Confirm your account.
 
   ![](../images/wp_getting_started/wp_getting_started_7.png)
 
@@ -60,33 +61,33 @@ CenturyLink Cloud's WordPress as a Service is a secure, Enterprise class, cloud-
 
 **Q: What are the differences between a standard WordPress install and a CenturyLink Cloud WordPress install?**
 
-A: The CenturyLink Cloud WordPress as a service team has compiled a [knowledge base article for known WordPress Limitaions](wordpress-known-limitations.md).
+A: The CenturyLink WordPress hosting team has compiled a [knowledge base article for known WordPress Limitaions](wordpress-known-limitations.md).
 
 **Q: I lost my Git confirmation email, how do I confirm my Git repository?**
 
 A: Use the link here: https://git.wordpress.ctl.io/users/confirmation/new
 
-**Q: How do I migrate my existing WordPress Site to CenturyLink WordPress as a Service?**
+**Q: How do I migrate my existing WordPress Site to CenturyLink's WordPress hosting platform?**
 
-A: The CenturyLink Cloud WordPress as a service team has compiled a [knowledge base article for manually migrating a WordPress site to CenturyLink Cloud](wordpress-site-migration-to-centurylink-cloud.md).
+A: The CenturyLink WordPress hosting team has compiled a [knowledge base article for manually migrating a WordPress site to CenturyLink Cloud](wordpress-site-migration-to-centurylink-cloud.md).
 
-**Q: Can I have persistent storage with CenturyLink Cloud WordPress as a Service?**
+**Q: Can I have persistent storage with CenturyLink WordPress Hosting?**
 
 A: WordPress persistent storage must be [configured  with CenturyLink Cloud Object Storage](wordpress-persistent-storage-configuration.md).
 
-**Q: How do I access the MySQL database for my WordPress Site?**
+**Q: How do I access the MySQL database for my WordPress site?**
 
 A: You can [access your WordPress database using external tools](https://www.ctl.io/knowledge-base/wordpress/wordpress-database-access-with-external-tools/).
 
-**Q: How do I install plugins and themes to my WordPress Site?**
+**Q: How do I install plugins and themes to my WordPress site?**
 
 A: You can [push plugins and themes to your WordPress site using your git repository](wordpress-plugin-installation.md).
 
-**Q: How do I send email (such as password resets) with my WordPress Site?**
+**Q: How do I send email (such as password resets) with my WordPress site?**
 
 A: You must [configure SMTP for your WordPress site](wordpress-SMTP-Configuration.md) in order to send email.
 
-**Q: Can I configure my own domain with CenturyLink Cloud WordPress as a Service?**
+**Q: Can I configure my own domain with CenturyLink WordPress Hosting?**
 
 A: You can [configure your own domain name](wordpress-custom-domain-configuration.md) via the CenturyLink Cloud Portal.
 

--- a/WordPress/wordPress-site-updates-with-git.md
+++ b/WordPress/wordPress-site-updates-with-git.md
@@ -6,11 +6,11 @@
   "contentIsHTML": false
 }}}
 
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
 
 ## Overview
 
-When you need to make changes to your CenturyLink WordPress as a Service site, git is the way to go. CenturyLink
+When you need to make changes to your site one CenturyLink Wordpress hosting, git is the way to go. CenturyLink
 provides you with a copy of your WordPress site's source code on our own secure, private
 [git servers](https://git.wordpress.ctl.io/). The general process is to clone your repository from our git
 hosting, make your changes in the local repository, commit your changes in git, and finally push your commits
@@ -19,7 +19,7 @@ are live in the next few minutes.
 
 ## Prerequisites
 
-- You have already successfully created your WordPress site with CenturyLink's WordPress as a Service.
+- You have already successfully created your WordPress site with the CenturyLink WordPress hosting platform.
 - You will log in to our git hosting with the CLC username you used when you created the site.
 - You have the site's WordPress administrative password, which is also your git password.
 
@@ -27,9 +27,7 @@ are live in the next few minutes.
 
 - You want to install or update a WordPress plug-in or theme.
 - You need to customize the WordPress core.
-- You are [migrating](wordpress-site-migration-to-centurylink-cloud.md) an existing WordPress site to CenturyLink's
-  WordPress as a Service.
-
+- You are [migrating](wordpress-site-migration-to-centurylink-cloud.md) an existing WordPress site to the CenturyLink WordPress hosting platform.
 Don't do this if you are just posting new content (text, images, video) to your WordPress site. Please review
 our documentation on [persistent object storage](wordpress-persistent-storage-configuration.md) for creating
 multimedia content.
@@ -88,7 +86,7 @@ and then [pushing them to a remote repository](https://git-scm.com/book/en/v2/Gi
 
   `git push origin master`
 
-4. From here, our git hosting lets the CenturyLink WordPress service know that you have made a change. The service will pull down your changes from the repository to update your live site! Please note that **only** commits pushed to the *master* branch will update your live site.
+4. From here, our git hosting lets the CenturyLink WordPress hosting platform know that you have made a change. The service will pull down your changes from the repository to update your live site! Please note that **only** commits pushed to the *master* branch will update your live site.
 
 ## That's It!
 

--- a/WordPress/wordpress-SMTP-Configuration.md
+++ b/WordPress/wordpress-SMTP-Configuration.md
@@ -5,11 +5,11 @@
   "attachments": [],
   "contentIsHTML": false
 }}}
-### IMPORTANT NOTE: CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage. During the Limited Beta there is no production Service Level Agreement.
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
 
 ### Overview
 
-Out of the box, WordPress sends email using the [PHP mail()](http://php.net/manual/en/function.mail.php) function. This function is unauthenticated and, for this reason, CenturyLink Cloud WordPress does not allow this functionality and includes the Easy WP SMTP plugin instead. Your WordPress site comes preconfigured with a limited SendGrid account. This account is limited to 1000 emails per month. Sending 1 email to 1000 recipients will immediately use all of these credits for the month. If you would like to send more emails, you will first need to reconfigure the SMTP plugin.
+Out of the box, WordPress sends email using the [PHP mail()](http://php.net/manual/en/function.mail.php) function. This function is unauthenticated and, for this reason, CenturyLink WordPress hosting does not allow this functionality and includes the Easy WP SMTP plugin instead. Your WordPress site comes preconfigured with a limited SendGrid account. This account is limited to 1000 emails per month. Sending 1 email to 1000 recipients will immediately use all of these credits for the month. If you would like to send more emails, you will first need to reconfigure the SMTP plugin.
 
 **In this example, Gmail will be used as the SMTP Relay and assumes the following:**
 

--- a/WordPress/wordpress-cloudflare-SSL-configuration.md
+++ b/WordPress/wordpress-cloudflare-SSL-configuration.md
@@ -5,9 +5,9 @@
   "attachments": [],
   "contentIsHTML": false
 }}}
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.### Overview:
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.### Overview:
 
-There are multiple methods that could be used to terminate SSL for an existing CenturyLink Cloud WordPress site. This method covers using CloudFlare CDN's SSL Termination.
+There are multiple methods that could be used to terminate SSL for an existing site hosted on the CenturyLink WordPress hosting plaform. This method covers using CloudFlare CDN's SSL Termination.
 
 ### This article assumes the following:
 
@@ -15,11 +15,11 @@ There are multiple methods that could be used to terminate SSL for an existing C
 
 ### Prerequisites:
 
-1. A CenturyLink WordPress site
-2. A Custom Fully Qualified Domain Name (FQDN) added to your WordPress Site.
+1. A site hosted on the CenturyLink WordPress hosting platform.
+2. A Custom Fully Qualified Domain Name (FQDN) added to your WordPress site.
 3. An existing [CloudFlare] (https://www.cloudflare.com/) account 
 4. Your customer site name must be configured for use with CloudFlare.
-### CloudFlare Settings SupportedFollowing the [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-) Knowledge Base Article, these are the settings CenturyLink WordPress suports.
+### CloudFlare Settings SupportedFollowing the [Configure SSL on Cloud Flare] (https://support.cloudflare.com/hc/en-us/articles/204468848-How-do-I-access-or-change-any-of-my-SSL-settings-) Knowledge Base Article, these are the settings CenturyLink suports.
 
 * SSL (with SPDY)						= Full, FLexible, or Off (Strict is not currently supported)
 * HTTP Strict Transport Security (HSTS)

--- a/WordPress/wordpress-custom-domain-configuration.md
+++ b/WordPress/wordpress-custom-domain-configuration.md
@@ -8,12 +8,12 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
 
 ### Overview
-CenturyLink Cloud WordPress supports custom domain name configuration after [setting up a new site](getting-started-with-wordpress-as-a-service.md).
+CenturyLink WordPress supports custom domain name configuration after [setting up a new site](getting-started-with-wordpress-as-a-service.md).
 
 ### Prerequisite
 

--- a/WordPress/wordpress-database-access-with-external-tools.md
+++ b/WordPress/wordpress-database-access-with-external-tools.md
@@ -8,7 +8,7 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
 and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
@@ -18,12 +18,11 @@ During the Limited Beta there is no production Service Level Agreement.
 WordPress uses a MySQL relational database for storing and retrieving content like posts, pages, image paths and
 comments as well as user login information.
 
-At times it is necessary to manage the database to resolve issues or add functionality.  With your CenturyLink Cloud
-WordPress site, you get your connection details and can use the tool of your choice to administer the database.
+At times it is necessary to manage the database to resolve issues or add functionality.  With your site, you get your connection details and can use the tool of your choice to administer the database.
 
 ### Prerequisites:
 
-* A CenturyLink WordPress site has been created.
+* A CenturyLink WordPress hosting site has been created.
 * A suitable MySQL client is installed and ready to use. There are many compatible options—from the MySQL
   command-line interface to MySQL Workbench and other third-party tools.
 

--- a/WordPress/wordpress-deployment-rollback.md
+++ b/WordPress/wordpress-deployment-rollback.md
@@ -8,7 +8,7 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
 and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
@@ -27,13 +27,13 @@ the rollback. The code in the CenturyLink Git Hosting repository is not modified
 
 ### Prerequisites
 
-* A WordPress site has been created using CenturyLink WordPress-as-a-Service.
+* A WordPress site has been created using the CenturyLink WordPress hosting platform.
 * A change to the site has been committed and pushed to CenturyLink Git Hosting.
 * The change is undesired and needs to be rolled back.
 
 ### Rollback Process
 
-1. [Log in](https://wordpress.ctl.io/) to CenturyLink WordPress-as-a-Service.
+1. [Log in](https://wordpress.ctl.io/) to the CenturyLink WordPress hosting platform.
 2. Find the site that needs to be rolled back in the list of sites.
 3. The "Roll Back" button is on the right side of the row. If no "Roll Back" button
    is visible for a given site, that site cannot be rolled back—either because it is

--- a/WordPress/wordpress-git-installation.md
+++ b/WordPress/wordpress-git-installation.md
@@ -8,7 +8,7 @@
 }}}
 
 
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
 
 ## Overview
 Git is a lightweight, opensource, version control system. Initially designed for Linux, Git has been packaged for simple implementation on most operating systems and is the software used to clone and update CenturyLink WordPress repositories.

--- a/WordPress/wordpress-git-repository-password-caching.md
+++ b/WordPress/wordpress-git-repository-password-caching.md
@@ -6,7 +6,7 @@
   "contentIsHTML": false
 }}}
 
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.
 
 ## Overview
 

--- a/WordPress/wordpress-git-ssh.md
+++ b/WordPress/wordpress-git-ssh.md
@@ -9,7 +9,7 @@
 IMPORTANT NOTE
 --------------
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only
 and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.

--- a/WordPress/wordpress-known-limitations.md
+++ b/WordPress/wordpress-known-limitations.md
@@ -1,5 +1,5 @@
 {{{
-  "title": "WordPress Known Limitations",
+  "title": "Known Limitations",
   "date": "10-19-2015",
   "author": "Jordan Mahaney, Bill Burge",
   "attachments": [],
@@ -8,12 +8,12 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
 
-## Known Platform Limitations for CenturyLink Cloud WordPress
-CenturyLink cloud WordPress is designed to minimize the management of a WordPress site by abstracting away many of the typical installation and maintenance tasks. The platform is cloud native, so there are several use cases that work differently than a traditional hosted WordPress site or may be completely unavailable.
+## Known Limitations of CenturyLink WordPress Hosting
+CenturyLink WordPress hosting is designed to minimize the management of a WordPress site by abstracting away many of the typical installation and maintenance tasks. The platform is cloud native, so there are several use cases that work differently than a traditional hosted WordPress site or may be completely unavailable.
 
 
 * [__WordPress Multisite__](#multisite)
@@ -24,21 +24,21 @@ CenturyLink cloud WordPress is designed to minimize the management of a WordPres
 * [__PHP mail__](#mail)
 
 ## <a name="multisite"></a>WordPress Multisite
-WordPress Multisite allows a single WordPress installation to house a network of separate sites. This feature is currently *disabled* by default in CenturyLink Cloud WordPress, and __is not__ supported.
+WordPress Multisite allows a single WordPress installation to house a network of separate sites. This feature is currently *disabled* by default in CenturyLink Cloud WordPress hosting, and __is not__ supported.
 
 ## <a name="storage"></a>Local File Storage
-CenturyLink Cloud WordPress __does not__ offer long term local file system storage for media, plugins, or themes. Traditional WordPress hosting on physical or virtual machines save site content to the local disk by default.  In the Cloud environment we have configured your WordPress site to work differently by allowing the site to use a previously created object storage bucket.
+CenturyLink WordPress hosting __does not__ offer long term local file system storage for media, plugins, or themes. Traditional WordPress hosting on physical or virtual machines save site content to the local disk by default.  In the Cloud environment we have configured your WordPress site to work differently by allowing the site to use a previously created object storage bucket.
 
 For more details please check out the knowledge base articles to [create an object storage bucket](https://www.ctl.io/knowledge-base/object-storage/using-object-storage-from-the-control-portal/) and how to [create a WordPress site with object storage](https://www.ctl.io/knowledge-base/wordpress/getting-started-with-wordpress-as-a-service/).
 
 > #### Media Content
-> The CenturyLink Cloud WordPress comes with a Cloud Storage plugin pre-installed. This is the preferred method of bypassing local file storage.
+>CenturyLink WordPress hosting comes with a cloud storage plugin pre-installed. This is the preferred method of bypassing local file storage.
 
 > #### Plugins and Themes
-Plugins and themes should be added to the git repository that comes with your CenturyLink Cloud WordPress site to ensure the changes are persisted long term.
+Plugins and themes should be added to the git repository that comes with your CenturyLink Cloud WordPress hosting to ensure the changes are persisted long term.
 
 ## <a name="ssl"></a>Custom SSL and HTTPS
-SSL and HTTPS are configured automatically when your CenturyLink Cloud WordPress site is installed. This configuration uses an SSL certificate issued to the infrastructure housing your site. There is currently no way to to replace the default certificates with custom SSL certificates .
+SSL and HTTPS are configured automatically when your WordPress site is installed. This configuration uses an SSL certificate issued to the infrastructure housing your site. There is currently no way to to replace the default certificates with custom SSL certificates .
 
 Custom SSL is supported by adding a [CDN](https://www.ctl.io/knowledge-base/wordpress/wordpress-cloudflare-ssl-configuration/) to your site which will allow you to bring your own SSL certificates.
 
@@ -54,12 +54,12 @@ As mentioned above, the recommended method of installing plugins and themes is v
 
 For more details on installing plugins and themes, see the [plugin install article](https://www.ctl.io/knowledge-base/wordpress/wordpress-plugin-installation/).
 
-We have also configured a [local development environment](https://www.ctl.io/knowledge-base/wordpress/wordpress-local-development/) that comes with all Centurylink Cloud WordPress sites and allows users to search, download and install plugins and themes from the WordPress admin console and then push those updates to your live site with [Git](https://www.ctl.io/knowledge-base/wordpress/wordpress-site-updates-with-git/).
+We have also configured a [local development environment](https://www.ctl.io/knowledge-base/wordpress/wordpress-local-development/) that comes with all sites created and allows users to search, download and install plugins and themes from the WordPress admin console and then push those updates to your live site with [Git](https://www.ctl.io/knowledge-base/wordpress/wordpress-site-updates-with-git/).
 
 ## <a name="ip-address"></a>Dedicated IP addresses
-CenturyLink Cloud WordPress sites do not have dedicated IP Addresses. Dedicated IP addresses are unnecessary given the design of underlying cloud infrastructure. Although dedicated IP addresses are commonly believed to be a requirement for building SEO and SSL, neither of use cases are impaired by having a lack of dedicated IP.
+The sites do not have dedicated IP Addresses. Dedicated IP addresses are unnecessary given the design of underlying cloud infrastructure. Although dedicated IP addresses are commonly believed to be a requirement for building SEO and SSL, neither of use cases are impaired by having a lack of dedicated IP.
 
 ## <a name="mail"></a>PHP mail
-The default PHP mail functionality is disabled in CenturyLink Cloud WordPress and cannot be enabled on the underlying infrastructure. We understand working e-mail is a crucial part of the WordPress forgot password functionality, so your WordPress site will come with a pre-installed plugin enabling use of e-mail service providers.
+The default PHP mail functionality is disabled and cannot be enabled on the underlying infrastructure. We understand working e-mail is a crucial part of the WordPress forgot password functionality, so your site will come with a pre-installed plugin enabling use of e-mail service providers.
 
 For more details on the email configuration, see [WordPress SMTP Configuration](wordpress-SMTP-Configuration.md)

--- a/WordPress/wordpress-local-development.md
+++ b/WordPress/wordpress-local-development.md
@@ -28,8 +28,7 @@ Introduction
 ------------
 
 WordPress is infinitely customizable with themes and plug-ins galore. A best practice is for WordPress developers
-to preview their changes on their local machine before uploading them to their production host. CenturyLink's
-WordPress as a Service offering makes these easy by integrating with Vagrant. Using Vagrant, a full development
+to preview their changes on their local machine before uploading them to their production host. CenturyLink WordPress hosting makes these easy by integrating with Vagrant. Using Vagrant, a full development
 environment can be created in minutes with the whole LEMP (Linux, nginx, MySQL, PHP) stack running inside a virtual
 machine.
 

--- a/WordPress/wordpress-persistent-storage-configuration.md
+++ b/WordPress/wordpress-persistent-storage-configuration.md
@@ -6,12 +6,12 @@
   "contentIsHTML": false
 }}}
 
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview
 
-CenturyLink Cloud WordPress sites utilize Object Storage for persistent storage of WordPress content files such as images and file attachments.  In order to utilize persistent storage you must manually configure a Centurylink Cloud Object Storage bucket, for use during WordPress site creation.
+CenturyLink WordPress hosting utilizes Object Storage for persistent storage of WordPress content files such as images and file attachments.  In order to utilize persistent storage you must manually configure a Centurylink Cloud Object Storage bucket, for use during WordPress site creation.
 
 Instructions on creating an object storage bucket can be found on the 
 [Using object storage from the control portal](../Object Storage/using-object-storage-from-the-control-portal.md) page.
 
-Once the object storage bucket has been created, the bucket can be applied during the [creation](https://www.ctl.io/knowledge-base/wordpress/getting-started-with-wordpress-as-a-service/) of your CenturyLink Cloud WordPress site.
+Once the object storage bucket has been created, the bucket can be applied during the [creation](https://www.ctl.io/knowledge-base/wordpress/getting-started-with-wordpress-as-a-service/) of your site.
 

--- a/WordPress/wordpress-plugin-installation.md
+++ b/WordPress/wordpress-plugin-installation.md
@@ -6,11 +6,11 @@
   "contentIsHTML": false
 }}}
 
-### IMPORTANT NOTECenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview
+### IMPORTANT NOTECenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.During the Limited Beta there is no production Service Level Agreement.## Overview
 
-CenturyLink Cloud WordPress sites use Git to deploy new WordPress code including new plugins.
+CenturyLink WordPress hosting use Git to deploy new WordPress code including new plugins.
 
-In order to activate a plugin you will need to download a WordPress Plugin and upload it into the Master branch of the Centurylink Git repository provided to you during your CenturyLink Cloud Wordpress site creation. This will then force a refresh of your WordPress blog and allow you to activate and configure the plugin.
+In order to activate a plugin you will need to download a WordPress Plugin and upload it into the Master branch of the Centurylink Git repository provided to you during your site creation. This will then force a refresh of your WordPress blog and allow you to activate and configure the plugin.
 
 **NOTE:** These instructions assume the following...
 

--- a/WordPress/wordpress-seo.md
+++ b/WordPress/wordpress-seo.md
@@ -10,12 +10,12 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
 
 During the Limited Beta there is no production Service Level Agreement.
 
 ### Overview
-The [Yoast SEO Plugin for WordPress](https://yoast.com/wordpress/plugins/seo/) is a popular, full-featured plugin for [SEO](https://codex.wordpress.org/Search_Engine_Optimization_for_WordPress).  Most of what you need to know is already covered in the [excellent Yoast SEO Tutorial](https://yoast.com/articles/wordpress-seo/) that you can find on their website.  In this KB article, we will cover how to install and setup Yoast SEO on the [CenturyLink Cloud WordPress](https://www.ctl.io/wordpress) platform so that you can take advantage of it.
+The [Yoast SEO Plugin for WordPress](https://yoast.com/wordpress/plugins/seo/) is a popular, full-featured plugin for [SEO](https://codex.wordpress.org/Search_Engine_Optimization_for_WordPress).  Most of what you need to know is already covered in the [excellent Yoast SEO Tutorial](https://yoast.com/articles/wordpress-seo/) that you can find on their website.  In this KB article, we will cover how to install and setup Yoast SEO on the [CenturyLink Cloud WordPress](https://www.ctl.io/wordpress) hosting platform so that you can take advantage of it.
 
 ### Installing the Yoast SEO Plugin
 
@@ -29,7 +29,7 @@ The [Yoast SEO Plugin for WordPress](https://yoast.com/wordpress/plugins/seo/) i
 
 Now that you have the plugin installed, go ahead and open the [Yoast SEO Tutorial](https://yoast.com/articles/wordpress-seo/).  In section 1, it makes several recommendations about setting up the URL and permalinks for your site.  For the most part, you can follow these recommendations as-is, but there are a couple of items to make note of:
 
-1. In section 1.1.1 regarding Permalink Structure, Yoast refers to a separate article on [changing your permalink structure](https://yoast.com/change-wordpress-permalink-structure/) which includes instructions for adding "redirects" to your _.htaccess_ file.  Please note that this is not necessary on the CenturyLink WordPress platform, and in fact will not work.  Instead, simply [modify your permalink structure](https://codex.wordpress.org/Using_Permalinks) using the WordPress admin console.
+1. In section 1.1.1 regarding Permalink Structure, Yoast refers to a separate article on [changing your permalink structure](https://yoast.com/change-wordpress-permalink-structure/) which includes instructions for adding "redirects" to your _.htaccess_ file.  Please note that this is not necessary on the CenturyLink WordPress hosting platform, and in fact will not work.  Instead, simply [modify your permalink structure](https://codex.wordpress.org/Using_Permalinks) using the WordPress admin console.
 
 2. In section 1.1.2, Yoast discusses choosing between _WWW_ and _non-WWW_ domain names for your site.  The CenturyLink platform supports either one, but bear in mind that you must create a custom _vanity URL_.  See our [KB article](../WordPress/wordpress-custom-domain-configuration.md) for assistance with setting up a custom domain name for your WordPress site.
 

--- a/WordPress/wordpress-site-migration-to-centurylink-cloud.md
+++ b/WordPress/wordpress-site-migration-to-centurylink-cloud.md
@@ -1,5 +1,5 @@
 {{{
-  "title": "WordPress Site Migration to CenturyLink Cloud",
+  "title": "WordPress Site Migration to CenturyLink WordPress Hosting",
   "date": "07-17-2015",
   "author": "Bill Burge",
   "attachments": [],
@@ -7,7 +7,7 @@
 }}}
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
 
@@ -27,7 +27,7 @@ There is currently no automated method for migrating an existing WordPress site 
 
 1.	An existing WordPress site
 2.	The prefix of your WordPress database tables on your existing WordPress site
-3.	A CenturyLink WordPress site
+3.	A WordPress site on CenturyLink WordPress hosting platform
 4.	The prefix of your CenturyLink WordPress database tables
 5. A CenturyLink Object Storage bucket including the access key id and secret access key
 
@@ -78,7 +78,7 @@ There is currently no automated method for migrating an existing WordPress site 
 
 3. Sync your Git repository (this will force a restart of your CenturyLink WordPress Site)
 
-## CenturyLink WordPress Site
+## CenturyLink WordPress Hosting
 
 1. Login to your WordPress site and activate All-in-One WP Migration
 

--- a/WordPress/wordpress-technical-specifications.md
+++ b/WordPress/wordpress-technical-specifications.md
@@ -7,13 +7,13 @@
 }}}
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage.
 
 During the Limited Beta there is no production Service Level Agreement.
 
 ## Overview
 
-CenturyLink Cloud WordPress as a Service runs in the CenturyLink Cloud utilizing the latest stable WordPress release.  System Specifactions and limitations have been chosen to maximize uptime, fulfill business needs, and ensure the security of customer's sites.
+The CenturyLink WordPress hosting platform runs on the CenturyLink Cloud utilizing the latest stable WordPress release.  System Specifactions and limitations have been chosen to maximize uptime, fulfill business needs, and ensure the security of customer's sites.
 
 ## System Specifications
 
@@ -38,12 +38,12 @@ _future product_
 
 ## Disallowed Services
 
-**phpmail()** is unauthenticated and not allowed on CenturyLink Cloud WordPress as a service.  [SMTP can be configured using a plugin](wordpress-SMTP-Configuration.md) to send mail from within WordPress.
+**phpmail()** is unauthenticated and not allowed in CenturyLink WordPress hosting.  [SMTP can be configured using a plugin](wordpress-SMTP-Configuration.md) to send mail from within WordPress.
 
 
 ## Disallowed php functions
 
-Many php Functions have been found to be WordPress security vulnerabilities, and these fucntions have been disabled for CenturyLink Cloud WordPress
+Many php Functions have been found to be WordPress security vulnerabilities, and these fucntions have been disabled for CenturyLink WordPress hosting.
 
 * **dl** - Loads a PHP extension at runtime
 * **exec** - Execute an external program

--- a/WordPress/wordpress-updating-core.md
+++ b/WordPress/wordpress-updating-core.md
@@ -10,7 +10,7 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
 
 During the Limited Beta there is no production Service Level Agreement.
 
@@ -96,7 +96,7 @@ At the present time, CenturyLink does not provide automated updates or upgrades 
 
 8. Test and verify in PROD
 
-  Now you can login to your Production WordPress site, and verify that it was successfully updated to the new version of WordPress core.
+  Now you can login to your production WordPress site, and verify that it was successfully updated to the new version of WordPress core.
 
   Occasionally, a WordPress core update may require updates to the database, and you may see a screen like this one:
 

--- a/WordPress/wordpress_woocommerce.md
+++ b/WordPress/wordpress_woocommerce.md
@@ -10,7 +10,7 @@
 
 ### IMPORTANT NOTE
 
-CenturyLink Cloud WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
+CenturyLink WordPress hosting is currently in a Limited Beta program with specific customers by invitation only and is not intended for production usage at this time.
 
 During the Limited Beta there is no production Service Level Agreement.
 


### PR DESCRIPTION
The product name of WordPress-as-a-Service is not allowed because of
trademarks. Currently there is no product name, so the change is to say
CenturyLink WordPress hosting or CenturyLink WordPress hosting platform.