### PR TITLE
Update 2015-11-03-cloud-platform-release-notes.md

### DIFF
--- a/Release Notes/2015-11-03-cloud-platform-release-notes.md
+++ b/Release Notes/2015-11-03-cloud-platform-release-notes.md
@@ -8,7 +8,7 @@
 
 ### New Features (3)
 
-* __Intrusion Prevention has been released for General Availability.__ The [Intrusion Prevention or IPS Product](https://www.ctl.io/intrusion-prevention-service/) is now available in all CenturyLink Cloud Data Centers, except for UC1.  
+* __Intrusion Prevention has been released for General Availability.__ The [Intrusion Prevention or IPS Product](https://www.ctl.io/intrusion-prevention-service/) is now available in all CenturyLink Cloud Data Centers.  
 
   The product installs a Trend Micro Agent on a host machine to protect that host against known and unknown vulnerabilities to operating systems and over 100 applications. The IPS agent automatically scans the host for newly installed applications every 24 hours, and if any are found, the protection policy is updated accordingly. The agent is also automatically updated with new Trend Micro patches to protect against new vulnerabilities. Details on installing IPS and configuring your event notification destinations are available in the Security section of our [knowledge base](https://www.ctl.io/knowledge-base/security/#1).
 
@@ -16,7 +16,7 @@
   * Installation via Blueprints 
   * Supports event notifications via WebHook and Email
   * Event data captured and forwarded to a syslog server 
-  * 90-day data retention of all event data, to help audits and compliance
+  * 13-week data retention of all event data, to help audits and compliance
 
 * __AppFog Control Portal UI Enhancements.__ [AppFog](https://www.ctl.io/appfog/) Developers can now perform common actions in the Control Portal UI:
 


### PR DESCRIPTION
modified previous release notes to remove UC1 limitation and reflect 13 weeks of data retention rather than 90 days per PO request.  