### PR TITLE
Updated dedicated-load-balancer-basic-management

### DIFF
--- a/Network/dedicated-load-balancer-basic-management.md
+++ b/Network/dedicated-load-balancer-basic-management.md
@@ -12,11 +12,11 @@
 <ul>
   <li>Must have a dedicated Netscaler available in your environment</li>
   <li>Must have an Admin login to your netscaler</li>
-  <li>Must have Java installed and configured correctly. See KB: <a href="(../general/how-to-configure-java-settings-to-access-web-user-interfaces.md)"> [How-to-Configure-Java]</a>
+  <li>Must have Java installed and configured correctly. See KB: <a href="./how-to-configure-java-settings-to-access-web-user-interfaces.md"> [How-to-Configure-Java]</a>
       <br />
     </a>
   </li>
-  <li>Understand the basic architecture of how a Netscaler works. See KB:<a href="(../network/load-balancing-dedicated-vs-shared)"> [Load-Balancing-Dedicated-vs-Shared​]</a>
+  <li>Understand the basic architecture of how a Netscaler works. See KB:<a href="/load-balancing-dedicated-vs-shared">Load Balancing Dedicated vs Shared</a>
       <br />
     </a>
   </li>

--- a/Network/dedicated-load-balancer-basic-management.md
+++ b/Network/dedicated-load-balancer-basic-management.md
@@ -12,7 +12,7 @@
 <ul>
   <li>Must have a dedicated Netscaler available in your environment</li>
   <li>Must have an Admin login to your netscaler</li>
-  <li>Must have Java installed and configured correctly. See KB: <a href="./how-to-configure-java-settings-to-access-web-user-interfaces.md"> [How-to-Configure-Java]</a>
+  <li>Must have Java installed and configured correctly. See KB: <a href="../General/how-to-configure-java-settings-to-access-web-user-interfaces.md"> How-to-Configure-Java</a>
       <br />
     </a>
   </li>

--- a/Network/dedicated-load-balancer-basic-management.md
+++ b/Network/dedicated-load-balancer-basic-management.md
@@ -12,12 +12,16 @@
 <ul>
   <li>Must have a dedicated Netscaler available in your environment</li>
   <li>Must have an Admin login to your netscaler</li>
-  <li>Must have Java installed and configured correctly. See KB:&nbsp;https://t3n.zendesk.com/entries/55258750-How-to-configure-Java-settings-to-access-web-user-interfaces
-    <a href="https://t3n.zendesk.com/entries/27208970-How-to-access-the-web-interface-of-a-Netscaler-Load-Balancer">
+  <li>Must have Java installed and configured correctly. See KB:&nbsp;how-to-configure-java-settings
+    <a href="https://www.ctl.io/knowledge-base/general/how-to-configure-java-settings-to-access-web-user-interfaces/">
       <br />
     </a>
   </li>
-  <li>Understand the basic architecture of how a Netscaler works. See KB:&nbsp;https://t3n.zendesk.com/entries/23688917-Load-Balancing-Dedicated-vs-Shared</li>
+  <li>Understand the basic architecture of how a Netscaler works. See KB:&nbsp;Load-balancing-dedicated-vs-shared/
+    <a href="https://www.ctl.io/knowledge-base/network/load-balancing-dedicated-vs-shared/">
+      <br />
+    </a>
+  </li>
 </ul>
 <h3>Notes</h3>
 <ul>

--- a/Network/dedicated-load-balancer-basic-management.md
+++ b/Network/dedicated-load-balancer-basic-management.md
@@ -12,13 +12,11 @@
 <ul>
   <li>Must have a dedicated Netscaler available in your environment</li>
   <li>Must have an Admin login to your netscaler</li>
-  <li>Must have Java installed and configured correctly. See KB:&nbsp;how-to-configure-java-settings
-    <a href="https://www.ctl.io/knowledge-base/general/how-to-configure-java-settings-to-access-web-user-interfaces/">
+  <li>Must have Java installed and configured correctly. See KB: <a href="(../general/how-to-configure-java-settings-to-access-web-user-interfaces.md)"> [How-to-Configure-Java]</a>
       <br />
     </a>
   </li>
-  <li>Understand the basic architecture of how a Netscaler works. See KB:&nbsp;Load-balancing-dedicated-vs-shared/
-    <a href="https://www.ctl.io/knowledge-base/network/load-balancing-dedicated-vs-shared/">
+  <li>Understand the basic architecture of how a Netscaler works. See KB:<a href="(../network/load-balancing-dedicated-vs-shared)"> [Load-Balancing-Dedicated-vs-Shared​]</a>
       <br />
     </a>
   </li>


### PR DESCRIPTION
Updated the links for:
in section Prerequisites, bullets 3 and 4 have links to internal (and obsolete) KBs:
https://support.ctl.io/hc/en-us/articles/204531055-Load-Balancing-Dedicated-vs-Shared
https://t3n.zendesk.com/entries/23688917-Load-Balancing-Dedicated-vs-Shared

TO
https://www.ctl.io/knowledge-base/network/load-balancing-dedicated-vs-shared/
https://www.ctl.io/knowledge-base/general/how-to-configure-java-settings-to-access-web-user-interfaces/