### PR TITLE
Update KB to utilize public TPM

### DIFF
--- a/Support/what-can-you-expect-from-centurylink-cloud-on-an-incident.md
+++ b/Support/what-can-you-expect-from-centurylink-cloud-on-an-incident.md
@@ -14,7 +14,7 @@
 </ul>
 <h3>"Ticket updates"</h3>
 <ol>
-  <li>All issues are worked in accordance with our prioritization matrix that can be found here: &nbsp;<a href="https://t3n.zendesk.com/entries/21651149-Ticket-Prioritization-Matrix">https://t3n.zendesk.com/entries/21651149-Ticket-Prioritization-Matrix</a>&nbsp;</li>
+  <li>All issues are worked in accordance with our prioritization matrix that can be found here: &nbsp;<a href="./ticket-prioritization-matrix">Ticket Prioritization Matrix</a>&nbsp;</li>
   <li>Please ensure that the ticket is prioritized correctly. In the majority of cases, the tickets are incorrectly classified.</li>
 </ol>
 <h3>"CenturyLink Cloud Expectations"</h3>


### PR DESCRIPTION
Updated KB to utilize the public KB URL for the ticket priority matrix instead of the zendesk link.