### PR TITLE
removed proxy config so no proxy is used

### DIFF
--- a/Object Storage/s3cmd-object-storage-management-for-linux-machines.md
+++ b/Object Storage/s3cmd-object-storage-management-for-linux-machines.md
@@ -137,9 +137,9 @@ preserve_attrs = True
 
 progress_meter = True
 
-proxy_host = localhost
+proxy_host =
 
-proxy_port = 8080
+proxy_port = 0
 
 recursive = False
 


### PR DESCRIPTION
This was discovered by a customer who copy pasted our .s3cfg file.  Whoever created it initially had a local proxy setup which no customers will actually use. 