### PR TITLE
Changing how the table displays information

### DIFF
--- a/Object Storage/object-storage-regions-and-service-points.md
+++ b/Object Storage/object-storage-regions-and-service-points.md
@@ -9,10 +9,7 @@
 The CenturyLink Cloud Object Storage service is available in multiple regions.  A region consists of two data centers, a primary and secondary.  You can only read and write to the primary.  You cannot directly interact with the secondary.  Under certain circumstances, the service will promote the secondary to primary.  Once you create a bucket in a specific region, you will need to use the appropriate service point to interact with that bucket.  Below we have listed the different regions, the individual data centers that make up a region, and the service points of that region.  
 
 ### Service Points
-|Region|Data Centers|Service Point|
-|---|---|---:|
-|Canada|CA3[P], CA1[S]|canada.os.ctl.io|
-|US-East|VA1[P], NY1[S]|useast.os.ctl.io|
-
-[P] - Primary data centers  
-[S] - Secondary data centers
+|Region|Primary Data Center|Secondary Data Center|Service Point|
+|---|---|---|---:|
+|Canada|CA3|CA1|canada.os.ctl.io|
+|US-East|VA1|NY1|useast.os.ctl.io|


### PR DESCRIPTION
Instead of marking the data centers as primary/secondary, I added columns for primary/secondary.  This is a much cleaner look.