### PR TITLE
update roles matrix per may 24th release

### DIFF
--- a/Accounts & Users/role-permissions-matrix.md
+++ b/Accounts & Users/role-permissions-matrix.md
@@ -2473,7 +2473,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2487,7 +2487,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2501,7 +2501,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2515,7 +2515,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2529,7 +2529,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2543,7 +2543,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2557,7 +2557,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2571,7 +2571,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2585,7 +2585,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2599,7 +2599,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2613,7 +2613,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>
@@ -2627,7 +2627,7 @@
   <td> </td>
   <td> </td>
   <td>x</td>
-  <td> </td>
+  <td>x</td>
   <td> </td>
   <td> </td>
   <td> </td>


### PR DESCRIPTION
per may 24th release, included Anti-Affinity as well since this was missed
Minor change to the Server Operator role in Control. The Server Operator role now has the ability to CREATE, EDIT and DELETE Vertical Autoscale, Horizontal Autoscale, and Alert Policies in Control (previously, it was VIEW only). This is a minor change which has no impact on cost or other features within the Control Portal.