### PR TITLE
UPDATE - Add exclusion for snapshots

### DIFF
--- a/Servers/how-to-clone-a-virtual-machine-os-instance.md
+++ b/Servers/how-to-clone-a-virtual-machine-os-instance.md
@@ -16,6 +16,7 @@ A clone is a copy of an existing virtual machine. When the cloning operation is 
 
 * Cloning is unsupported for customers who leverage virtual machines with the multi-vNIC feature
 * Source machines must not be domain joined.
+* Before attempting to clone a virtual machine, all snapshots must be removed.  A virtual machine with an active snapshot will fail the clone process.
 
 ### Important Notices
 


### PR DESCRIPTION
Added third bullet point to inform customer that snapshots on VMs will cause the clone process to fail.

Added text:
"Before attempting to clone a virtual machine, all snapshots must be removed.  A virtual machine with an active snapshot will fail the clone process."

Related to Customer Care PM:
https://t3n.zendesk.com/agent/tickets/1282410