### PR TITLE
Broken Link Update - Chyrp Homepage

### DIFF
--- a/Ecosystem Partners/Marketplace Guides/getting-started-with-chyrp-blueprint.md
+++ b/Ecosystem Partners/Marketplace Guides/getting-started-with-chyrp-blueprint.md
@@ -14,7 +14,7 @@ Chyrp is a lightweight, PHP-powered blogging engine with an intuitive WYSIWYG ed
 ### Description
 The CenturyLink Chyrp Blueprint provides a click-through solution to install and configure Chyrp on the Linux platform.
 
-For more information, please visit [Chyrp](http://chyrp.net).
+For more information, please visit [Chyrp](https://github.com/chyrp/chyrp).
 
 ### Audience
 CenturyLink Cloud Users


### PR DESCRIPTION
Received a report from www.whoishostingthis.com about the linked homepage being down. According to the their Chyrp page (http://www.whoishostingthis.com/resources/chyrp), it's been down since September 2015. Re-linked to their GitHub repo (https://github.com/chyrp/chyrp).