### PR TITLE
Fixed typo in URL for role permissions matrix

### DIFF
--- a/Accounts & Users/role-permissions-matrix.md
+++ b/Accounts & Users/role-permissions-matrix.md
@@ -13,4 +13,4 @@ Any user of CenturyLink Cloud products and services.
 
 ### Overview
 
-View the [Role Permission Matrix](//www.ctl.io/role-permissions-matrix/) for CenturyLink Cloud.
+View the [Role Permission Matrix](/www.ctl.io/role-permissions-matrix/) for CenturyLink Cloud.


### PR DESCRIPTION
Fixed typo in URL for role permissions matrix