### PR TITLE
Update creating-users.md

### DIFF
--- a/Accounts & Users/creating-users.md
+++ b/Accounts & Users/creating-users.md
@@ -1,7 +1,7 @@
 {{{
   "title": "Creating Users",
-  "date": "10-16-2014",
-  "author": "Troy Schneringer",
+  "date": "10-26-2017",
+  "author": "CenturyLink Cloud Customer Care",
   "attachments": [],
   "contentIsHTML": false
 }}}
@@ -12,7 +12,10 @@ Users can be configured for both the Control Portal and the API.
 
 You can manage users on your account by going to the Control Portal > Settings > Users.
 
-**Note:** Permissions must be configured for a user after they are created in order to have access within the control. Learn more about [User Permissions](user-permissions.md).
+**Important Notes:** 
+* Permissions must be configured for a user after they are created in order to have access within the control. Learn more about [User Permissions](user-permissions.md).
+
+* A Control account username must be globally unique in the platform and cannot be reused, or otherwise reissued/migrated into a different Control account. If the user account is deleted, it cannot be reinstated or repurposed for another user. This constraint is currently an intentional design specification built into the CenturyLink Cloud Control platform.
 
 1. Click the "Create New User" button.
 


### PR DESCRIPTION
Inform that Control user accounts must be globally unique and cannot be reissued into a different account, or reinstated after being deleted.