### PR TITLE
Correct VMX version

### DIFF
--- a/Servers/self-service-vm-import-ovf-requirements.md
+++ b/Servers/self-service-vm-import-ovf-requirements.md
@@ -27,7 +27,7 @@ Your OVF must meet the following requirements to be imported successfully.
 - Only a single image should be present. Multiple images (for example a vApp) are not supported. Refer to the [Open Virtualization Format White Paper](http://www.dmtf.org/sites/default/files/standards/documents/DSP2017_2.0.0.pdf) for more information.
 - The OVF file name must not include a "`.`" or a "`-`".
 - Ping should not be blocked on the firewall.
-- The VMware hardware version (VMX) must be 11 or lower.
+- The VMware hardware version (VMX) must be 8 or lower.
 - The latest version of VMware Tools must be installed. You will get the error message that reads "the guest operations agent is out of date" if your version is not correct.
 - The OVF must be exported from VMware. Other hypervisors are not supported.
 - The current Administrator or Root password must be input during the import process.


### PR DESCRIPTION
Changed our VMX version requirement from 11 to 8. While we believe the platform supports vmx hardware version up to this level, we have not tested it for self service imports yet.