### PR TITLE
RHEL7 Consistent Network Setting

### DIFF
--- a/Servers/self-service-vm-import-ovf-requirements.md
+++ b/Servers/self-service-vm-import-ovf-requirements.md
@@ -45,6 +45,9 @@ Your OVF must meet the following requirements to be imported successfully.
   - `rm /etc/udev/rules.d/70-persistent-net.rules`
 - Create a blank file named **75-persistent-net-generator.rules** to prevent the build of the persistent net rules file.
   - `touch /etc/udev/rules.d/75-persistent-net-generator.rules`
+  
+#### Specific Requirements for Red Hat 7 64-Bit OVFs
+- Ensure Consistent Network Device Naming is enabled.
 
 ### Other Notes
 - In addition, the import function will enable the following capabilities if they are not available on your OVF image:


### PR DESCRIPTION
Added note for RHEL7 servers requiring "Consistent Network Device Naming" to be enabled for successful import.