### PR TITLE
Update network-exchange-clc-endpoint-guide.md

### DIFF
--- a/Network/network-exchange-clc-endpoint-guide.md
+++ b/Network/network-exchange-clc-endpoint-guide.md
@@ -1,7 +1,7 @@
 {{{
   "title": "Network Exchange CenturyLink Cloud Endpoint Guide",
-  "date": "04-27-2017",
-  "author": "Rob Lesieur",
+  "date": "03-28-2018",
+  "author": "Marco Paolillo",
   "attachments": [],
   "related-products" : [],
   "contentIsHTML": false,
@@ -11,11 +11,13 @@
 ### CLC Endpoint Connectivity Prerequisites
 
 * End Users must establish a CenturyLink Cloud (CLC) master account and sub-accounts, the latter to create isolation between the networking resources of the business units of their enterprise. The Exchanges created under each sub-account will be logically isolated from one another.
-* The desired CenturyLink Cloud must be supported within Network Exchange. See the Network Exchange Availability Matrix and Configuration Guide for supported data centers.
+* For any existing CLC accounts that wish to use Network Exchange, it is necessary to migrate them to a Dedicated VR.  Having a dedicated virtual routing table allows each customer to have their own set of IPs’ from a cloud connectivity standpoint.  A Dedicated VR is also required for automation to work when creating connectivity to the cloud.  
+To create a dedicated virtual routing table (Dedicated VR), the VR will need to be created and all existing IP blocks the customer is using will need to converge to the new VR.  To initiate this process, create a ticket with the CenturyLink Cloud help desk.  
+* The desired CenturyLink Cloud must be supported within Network Exchange. See the *Network Exchange Availability Matrix and Configuration Guide* for supported data centers.
 
 ### CLC Endpoint Capabilities
 
-* Up to 10Gb/s of shared bandwidth to and from CenturyLink Cloud. Network performance is offered as “best effort”. [reference SLA]
+* Up to 10Gb/s of shared bandwidth to and from CenturyLink Cloud. Network performance is offered as “best effort”. 
 * Fully automated setup and tear down of CenturyLink Cloud connections to the End User’s VLANs.
 * CLC firewall rules are automatically updated as CLC endpoints are added or deleted.
 * BGP is used for dynamically managing routes between Network Exchange and CenturyLink Cloud.
@@ -23,5 +25,6 @@
 ### Notes
 
 * The Network Exchange fabric leverages the economics of shared networking while logically isolating network traffic between Exchanges, even within the same End User account. Dedicated access to CenturyLink Cloud is not supported with Network Exchange.
-* Currently, an End User may only add the CenturyLink Cloud endpoint(s) present in the same metropolitan area as the serving instance of Network Exchange. Where more than one CLC endpoint is served, all may be included in a given Exchange. See the Network Exchange Availability Matrix and Configuration Guide for more information.
-* No CLC service ticket is required to add or delete a CenturyLink Cloud endpoint.
+* Currently, an End User may only add the CenturyLink Cloud endpoint(s) present in the same metropolitan area as the serving instance of Network Exchange. Where more than one CLC endpoint is served, all may be included in a given Exchange. See the *Network Exchange Availability Matrix and Configuration Guide* for more information.
+* A CLC service ticket is not required to add or delete a CenturyLink Cloud endpoint.
+* For additional information regarding the Network Exchange architecture and use cases, please consult the *Network Exchange Architecture and Technical Guide*.


### PR DESCRIPTION
Added bullet item for migrating existing CLC accounts to dedicated VR, deleted SLA reference, italicized Availability Matrix in two spots, slight wording change in next to last bullet and added reference to NetX Architecture Guide.