### PR TITLE
Reworded to be Managed Hosting via HAN

### DIFF
--- a/Network/network-exchange-clc-managed-hosting-endpoint-guide.md
+++ b/Network/network-exchange-clc-managed-hosting-endpoint-guide.md
@@ -18,9 +18,6 @@
 
 * Rate limit choices of 1Gb/s and 10Gb/s through shared bandwidth to and from the [Managed Hosting Network (HAN)](https://www.ctl.io/architecture/cns-architecture/), which is a CenturyLink network infrastructure used to provide connectivity for Managed Server customers, NAS Customers, and other CenturyLink managed services. Network performance is offered as “best effort”.
 * BGP is used for dynamically managing routes between Network Exchange and the End User’s network.
-
-automated setup and tear down of connections to the End User’s dedicated ports on the terminating Network Exchange equipment
-
 * Near fully automated setup and tear down of connections between the Managed Hosting Network (HAN) and the dedicated ports on the terminating Network Exchange equipment. HAN requires additional configurations to be made outside of the Network Exchange portal.
 
 ### Notes

--- a/Network/network-exchange-clc-managed-hosting-endpoint-guide.md
+++ b/Network/network-exchange-clc-managed-hosting-endpoint-guide.md
@@ -1,28 +1,30 @@
 {{{
-  "title": "Network Exchange CenturyLink Managed Hosting Endpoint Guide",
-  "date": "06-14-2017",
-  "author": "Rob Lesieur",
+  "title": "Network Exchange CenturyLink Managed Hosting via HAN Endpoint Guide",
+  "date": "05-01-2018",
+  "author": "Jason Holland",
   "attachments": [],
   "related-products" : [],
   "contentIsHTML": false,
   "sticky": false
 }}}
 
-### Managed Hosting Endpoint Connectivity Prerequisites
+### Managed Hosting via HAN Endpoint Connectivity Prerequisites
 
 * End Users must establish a CenturyLink Cloud (CLC) master account and sub-accounts, the latter to create isolation between the networking resources of the business units of their enterprise. The Exchanges created under each sub-account will be logically isolated from one another.
 * The desired Managed Hosting site must be supported within Network Exchange. See the Network Exchange Availability Matrix and Configuration Guide for supported data centers.
-* The End User must separately order two instances of HAN VLAN Access in advance of provisioning Network Exchange. The VLAN IDs supplied by CenturyLink will be used in the provisioning process.
+* Two instances of Managed Hosting Network (HAN) VLAN Access are required and will be automatically ordered with this Endpoint.
 
-### Managed Hosting Endpoint Capabilities
+### Managed Hosting via HAN Endpoint Capabilities
 
-* Up to 10Gb/s of shared bandwidth to and from the Managed Hosting site. Network performance is offered as “best effort”. [reference SLA]
+* Rate limit choices of 1Gb/s and 10Gb/s through shared bandwidth to and from the [Managed Hosting Network (HAN)](https://www.ctl.io/architecture/cns-architecture/), which is a CenturyLink network infrastructure used to provide connectivity for Managed Server customers, NAS Customers, and other CenturyLink managed services. Network performance is offered as “best effort”.
 * BGP is used for dynamically managing routes between Network Exchange and the End User’s network.
-* Fully automated provisioning of Exchanges once HAN VLAN Access has been obtained.
+
+automated setup and tear down of connections to the End User’s dedicated ports on the terminating Network Exchange equipment
+
+* Near fully automated setup and tear down of connections between the Managed Hosting Network (HAN) and the dedicated ports on the terminating Network Exchange equipment. HAN requires additional configurations to be made outside of the Network Exchange portal.
 
 ### Notes
 
-* This endpoint guide applies to Managed Hosting endpoints connected to other endpoints over the shared network capability of HAN. Managed Hosting End Users wishing to connect to Managed Hosting using direct connections should refer to the CenturyLink Dedicated Access Endpoint Guide.
+* Managed Hosting End Users wishing to connect to Managed Hosting using direct connections should refer to the Network Exchange CenturyLink Managed Hosting Dedicated Access Endpoint Guide.
 * The Network Exchange fabric leverages the economics of shared networking while logically isolating network traffic between Exchanges, even within the same End User account. Dedicated access to CenturyLink Cloud is not supported with Network Exchange.
 * Currently, an End User may only add the Managed Hosting endpoint(s) present in the same metropolitan area as the serving instance of Network Exchange. Where more than one Managed Hosting endpoint is served, all may be included in a given Exchange. See the Network Exchange Availability Matrix and Configuration Guide for more information.
-* An order for two instances of HAN VLAN Access must be placed and the order completed before provisioning the Managed Hosting endpoint.


### PR DESCRIPTION
this was originally misleading. It should be Managed Hosting via HAN. appropriate updates made.