### PR TITLE
Escape jinja syntax in example code block.

### DIFF
--- a/Cloud Application Manager/Automating Deployments/running-code-outside-an-instance.md
+++ b/Cloud Application Manager/Automating Deployments/running-code-outside-an-instance.md
@@ -64,7 +64,7 @@ chmod +x $pythonfile
 $pythonfile
 
 cat <<NODE> $nodefile
-console.log('printing from node the value of variable1: {{ variable1 }}')
+console.log('printing from node the value of variable1: {{ '{{' }} variable1 {{ '{{' }}')
 
 NODE
 


### PR DESCRIPTION
The jinja syntax was parsed and removed from the example code block, but the code should show the syntax as it is.