### PR TITLE
Update network-exchange-clc-dedicated-access-endpoint-guide.md

### DIFF
--- a/Network/network-exchange-clc-dedicated-access-endpoint-guide.md
+++ b/Network/network-exchange-clc-dedicated-access-endpoint-guide.md
@@ -28,5 +28,6 @@
 * The user will have a choice between a 1Gbps and 10Gbps connection. The optics used to connect to Network Exchange are one of:
   * QFX-SFP-1GE-LX SFP 1000BASE-LX Gigabit Ethernet Optics, 1,310 nm for 10 km transmission on single mode fiber-optic (SMF)
   * QFX-SFP-10GE-LR SFP+ 10GBASE-LR 10 Gigabit Ethernet Optics, 1,310 nm for 10 km transmission on single mode fiber-optic (SMF)
+  * QFX-SFP-1GE-T 1000BASE-T SFP Copper SFP, Up to 100M (328 ft.) on Cat 5 unshielded twisted-pair copper cabling
 * Service Delivery will obtain the proper optics for the other end of the cross connect, matching speed and type (SMF). 
 * Currently, an End User may only add Dedicated Access Endpoint(s) present in the same metropolitan area as the serving instance of Network Exchange. Where more than one Dedicated Access endpoint is served, all may be included in a given Exchange. See the [Network Exchange Availability Matrix and Configuration Guide](../Network/network-exchange-connectivity-matrix-configuration-guide.md) for more information.


### PR DESCRIPTION
added copper optic to match other NetX doc and Big Machines