### PR TITLE
Remove datacenters from region endpoint table.

### DIFF
--- a/Object Storage/object-storage-regions-and-service-points.md
+++ b/Object Storage/object-storage-regions-and-service-points.md
@@ -7,14 +7,14 @@
 }}}
 
 ### Description
-The CenturyLink Cloud Object Storage service is available in multiple regions. A region consists of two data centers, a primary and a secondary. You can only read and write to the primary. You cannot directly interact with the secondary. Under certain circumstances, the service promotes the secondary to primary. Once you create a bucket in a specific region, you need to use the appropriate service point to interact with that bucket.  
+The CenturyLink Cloud Object Storage service is available in multiple regions. Once you create a bucket in a specific region, you need to use the appropriate service point to interact with that bucket.  
 
-Here is a list of the different regions, the individual data centers that comprise the region, and the region service points.  Please note, too, that our service endpoints leverage wildcard (SSL) certificates for the respective region, as shown in the table below.
+Here is a list of the different regions and the region service points.  Please note, too, that our service endpoints leverage wildcard (SSL) certificates for the respective region, as shown in the table below.
 
 ### Service Points
-Region|Primary Data Center|Secondary Data Center|Service Point|SSL Certificate
----|---|---|---|---:|
-Canada|CA1|CA3|canada.os.ctl.io|*.canada.os.ctl.io|
-US-West|WA1|UC1|uswest.os.ctl.io|*.uswest.os.ctl.io|
-US-East|VA1|NY1|useast.os.ctl.io|*.useast.os.ctl.io|
-Germany|DE1|DE3|germany.os.ctl.io|*.germany.os.ctl.io
+Region|Service Point|SSL Certificate
+---|---|---:|
+Canada|canada.os.ctl.io|*.canada.os.ctl.io|
+US-West|uswest.os.ctl.io|*.uswest.os.ctl.io|
+US-East|useast.os.ctl.io|*.useast.os.ctl.io|
+Germany|germany.os.ctl.io|*.germany.os.ctl.io


### PR DESCRIPTION
We don't want to explicitly call out individual datacenters when referring to object storage. The only things users need to know about in order to use object storage are the regions.