### PR TITLE
Add table of contents, common sections and review styles to AWS article

### DIFF
--- a/Cloud Application Manager/Deploying Anywhere/using-your-aws-account.md
+++ b/Cloud Application Manager/Deploying Anywhere/using-your-aws-account.md
@@ -1,33 +1,52 @@
 {{{
 "title": "Using AWS",
-"date": "09-01-2016",
-"author": "",
+"date": "09-24-2018",
+"author": "Guillermo Sanchez",
 "attachments": [],
 "contentIsHTML": false
 }}}
 
 ### Using AWS
 
-Deploy to AWS from Cloud Application Manager as follows.
+**In this article:**
+
+* [Overview](#overview)
+* [Audience](#audience)
+* [Prerequisites](#prerequisites)
+* [Connect Your AWS Account in Cloud Application Manager](#connect-your-aws-account-in-cloud-application-manager)
+* [Choosing the right policy](#choosing-the-right-policy)
+* [Add Custom AMIs in Cloud Application Manager](#add-custom-amis-in-cloud-application-manager)
+* [Deploy to Your AWS Account](#deploy-to-your-aws-account)
+* [EC2 (Linux and Windows)](#ec2-linux-and-windows)
+* [AWS ECS](#aws-ecs)
+* [Shutdown and Terminate Instances in AWS](#shutdown-and-terminate-instances-in-aws)
+* [Contacting Cloud Application Manager Support](#contacting-cloud-application-manager-support)
+
+### Overview
+
+This article is meant to assist users of Cloud Application Manager to learn how to deploy any workload to AWS from Cloud Application Manager as follows.
 
 * For EC2 (Linux and Windows) use [deployment policies](../Automating Deployments/deploymentpolicy-box.md). Select a policy when you launch workloads from boxes.
 * For any other AWS service, configure a custom [CloudFormation box](../Automating Deployments/template-box.md).
 
-We orchestrate with AWS APIs in the backend to provision, install, and manage the lifecycle of your workloads based on the box configuration.
+Cloud Application Manager orchestrates with AWS APIs in the backend to provision, install, and manage the lifecycle of your workloads based on the box configuration.
 
-**In this article:**
-* Connect your AWS account in Cloud Application Manager
-* Add custom AMIs in Cloud Application Manager
-* Deploy to Your AWS Account
-* Auto-Discover Instances
+### Audience
 
-## Connect Your AWS Account in Cloud Application Manager
+All Cloud Application Manager users who wants to deploy workloads into AWS.
+
+### Prerequisites
+
+* Access to Cloud Application Manager Management site.
+* The user must have an existing AWS account or should be an Administrator of the organization in Cloud Application Manager to [create](../Cloud Optimization/partner-cloud-integration-aws-new.md) or [bring](../Cloud Optimization/partner-cloud-integration-aws-existing.md) an AWS account to be managed by CenturyLink.
+
+### Connect Your AWS Account in Cloud Application Manager
 
 Before you deploy in AWS, you need to connect your AWS account in Cloud Application Manager. Watch this video for details.
 
 <iframe frameborder="0" height="316" src="//player.vimeo.com/video/126177639" width="561"></iframe>
 
-**Choosing the right policy**
+### Choosing the right policy
 
 The AWS IAM Policy regulates what Cloud Application Manager is allowed to do and see from your account. Depending on your usage you might want to restrict more or less the operations allowed.
 
@@ -37,7 +56,7 @@ For example, if you are planning to deploy RDS and ElastiCache from CloudFormati
 
 Here is an example of a common policy that give access to some AWS services but not all:
 
-```
+```json
 {
 "Version": "2012-10-17",
 "Statement": [
@@ -93,7 +112,7 @@ The full list of possible actions is described [here](http://docs.aws.amazon.com
 
 If you are not planning to use CloudFormation template boxes and you want to use Script Boxes and Deployment Policy Boxes, here is the minimal policy required for them to work:
 
-```
+```json
 {
 "Version": "2012-10-17",
 "Statement": [
@@ -248,7 +267,7 @@ If you are not planning to use CloudFormation template boxes and you want to use
         "ce:GetDimensionValues",
         "ce:GetTags",
         "support:*",
-        "sts:AssumeRole"        
+        "sts:AssumeRole"
     ],
     "Sid": "Stmt1378777340000",
     "Resource": [
@@ -260,19 +279,18 @@ If you are not planning to use CloudFormation template boxes and you want to use
 }
 ```
 
-**Create an IAM Role with the Policy chosen**
+#### Create an IAM Role with the Policy chosen
 
 1. Create a custom AWS policy and copy, paste the permissions chosen before and name it CAM_Policy. You can edit these permissions before if some deployment fails because of the lack of permissions.
 
 2. Create an IAM role by clicking the create role button.  Then select the **Another AWS Account tab**. Provide the information below
 
-   * Account ID: 540339316802
-   * External ID: elasticbox
-   * Require MFA: Leave unselected
-                                                                                                                                       
-   
-   Then, add the policy you created (**CAM_Policy**) as well as the policy called **ReadOnlyAccess**. 
-                                                   
+   * **Account ID**: 540339316802
+   * **External ID**: elasticbox
+   * **Require MFA**: Leave unselected
+
+   Then, add the policy you created (**CAM_Policy**) as well as the policy called **ReadOnlyAccess**.
+
 3. Register the IAM role in Cloud Application Manager.
    * **Important:** If you use Cloud Application Manager as an appliance, connect to your AWS account using the secret and key credentials.
 
@@ -301,13 +319,11 @@ To deploy workloads to an EC2 instance, create a [deployment policy](../Automati
 
 ![aws-deployment-policy-2.png](../../images/cloud-application-manager/aws-deployment-policy-3.png)
 
-
 **Deployment**
 
 | Deployment Option | Description |
 |-------------------|-------------|
 | Provider | This shows the name or GUID of the AWS provider account in Cloud Application Manager. If you don’t have access to the provider account, you see the GUID. |
-
 
 **Resource**
 
@@ -315,11 +331,10 @@ To deploy workloads to an EC2 instance, create a [deployment policy](../Automati
 |-------------------|-------------|
 | Region | Select the region where you want to create the instance, for example, us-east-1.|
 | AMI | Select a public, private, or shared AWS or an AWS community based AMI available by location.|
-| Instance Type |	Select an instance type that’s pre-determined by the size of compute, memory, and network resources from the list that AWS provides, for example, db.t1.micro.|
+| Instance Type | Select an instance type that’s pre-determined by the size of compute, memory, and network resources from the list that AWS provides, for example, db.t1.micro.|
 | Keypairs | Select a key pair you created in AWS to connect to the instance or select None if you don’t want SSH access to the instance.|
 |IAM Role | Select one to assign an existing IAM role to the instance. This allows the instance to make and accept API requests securely using the permissions defined by the role. To let Cloud Application Manager view and pass the existing role to the instance, update the Cloud Application Manager IAM role policy with the listed permissions. To learn more about IAM roles, see the [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#permission-to-pass-iam-roles).|
-| Instances |	Select the number of instances to launch.|
-
+| Instances | Select the number of instances to launch.|
 
 **Network**
 
@@ -342,7 +357,7 @@ Select from General Purpose (SSD), Provisioned IOPS (SSD) or Magnetic volume typ
 
 Follow these steps to add more volumes.
 
-**Steps**
+#### Steps
 
 Configure volumes. Select a [type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html), [device mapping](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html), size, and IOPS where available.
 
@@ -385,6 +400,7 @@ When deploying via AWS, we register the instance to the load balancer and automa
 ### AWS ECS
 
 To deploy workloads to an ECS instances:
+
 * AWS ECS
 * Image Lifecycle
 * Deploy the Instance
@@ -395,13 +411,11 @@ To deploy workloads to an ECS instances:
 
 Create a new policy box of type “Amazon EC2 Container Service” or use the one your admin shared with you.
 
-
 **Deployment**
 
 | Deployment Option | Description |
 |-------------------|-------------|
 | Provider | This shows the name or GUID of the AWS provider account in Cloud Application Manager . If you don’t have access to the provider account, you see the GUID. |
-
 
 **Resource**
 
@@ -409,11 +423,10 @@ Create a new policy box of type “Amazon EC2 Container Service” or use the on
 |-------------------|-------------|
 | Region | Select the region where you want to create the instance, for example, us-east-1.|
 | Cluster | Select the cluster where you want to deploy you container. |
-| CPU Units |	The number of cpu units to reserve for the container. A container instance has 1,024 cpu units for every CPU core.|
+| CPU Units | The number of cpu units to reserve for the container. A container instance has 1,024 cpu units for every CPU core.|
 | Memory | The number of MiB of memory to reserve for the container. If your container attempts to exceed the memory allocated here, the container is killed.|
 | IAM Role | Select one to assign an existing IAM role to the instance. This allows the instance to make and accept API requests securely using the permissions defined by the role. To let Cloud Application Manager view and pass the existing role to the instance, update the Cloud Application Manager IAM role policy with the listed permissions. To learn more about IAM roles, see the [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#permission-to-pass-iam-roles).|
 | Instances | Select the number of instances to launch. |
-
 
 **Network**
 
@@ -422,7 +435,7 @@ Create a new policy box of type “Amazon EC2 Container Service” or use the on
 | Load Balancing | Select the load balancer to be used by the container. |
 | Port Mappings | Maps the ports between the container port and the host port. |
 
-### Image Lifecycle
+#### Image Lifecycle
 
 **Build the Image**
 
@@ -430,10 +443,9 @@ Use the ebcli to build the image.
 
 **Sintax**
 
-```
+```sh
 ebcli build ”<box ID>” [-t “<image name>”] [--image <image name>] [--boxes-path <boxes path>]
 ```
-
 
 **Parameters**
 
@@ -443,25 +455,27 @@ ebcli build ”<box ID>” [-t “<image name>”] [--image <image name>] [--box
 | –image | Name of the base image to be used. E.g. ubuntu:14.04 or Centos. |
 | –boxes-path |	Path where the boxes are located. |
 
-### Push the Image
+##### Push the Image
+
 Use the docker client to push the image to your favorite docker registry. If you have questions about this step, check out the official Docker documentation about images.
 
-**Syntax**
+Syntax:
 
-```
+```sh
 docker push “<image name>”
 ```
 
-### Post the Image
+##### Post the Image
+
 Use the ebcli to post the image to your box
 
-**Syntax**
+Syntax:
 
-```
+```sh
 ebcli post “<docker image>”
 ```
 
-### Deploy the Instance
+##### Deploy the Instance
 
 Deploy the instance as you would do for a regular deployment, but instead, select the previously created deployment profile. The box will be deployed as a container within the ECS cluster selected in the Deployment Policy.
 
@@ -469,7 +483,7 @@ Deploy the instance as you would do for a regular deployment, but instead, selec
 
 As soon as the state of an instance changes to shutdown or terminated, you stop incurring charges for that instance.
 
-**Shutdown Instance**
+#### Shutdown Instance
 
 When a shutdown operation is executed from Cloud Application Manager, the instance is stopped. AWS don't charge hourly usage for a stopped instance, or data transfer fees, but AWS do charge for the storage for any Amazon EBS volumes. Each time you start a stopped instance AWS charge a full instance hour, even if you make this transition multiple times within a single hour.
 
@@ -482,7 +496,7 @@ You can modify the following attributes of an instance only when it is stopped:
 * Kernel
 * RAM disk
 
-**Terminate Instance**
+#### erminate Instance
 
 When you terminate an instance, the whole history of the instance is kept in Cloud Application Manager and you can use it as a reference for other instances, to copy the variables or to clone the instance. The instance in AWS is terminated.
 
@@ -501,5 +515,6 @@ We’re sorry you’re having an issue in [Cloud Application Manager](https://ww
 For issues related to API calls, send the request body along with details related to the issue.
 
 In the case of a box error, share the box in the workspace that your organization and Cloud Application Manager can access and attach the logs.
+
 * Linux: SSH and locate the log at /var/log/elasticbox/elasticbox-agent.log
 * Windows: RDP into the instance to locate the log at ProgramDataElasticBoxLogselasticbox-agent.log


### PR DESCRIPTION
@EfrenRey, there was already a mention to include a `ReadOnlyAccess` policy: 

> ...as well as the policy called **ReadOnlyAccess**.

I guess that should suffice for brownfield native resources discovery, so I just updated the article a little bit.

👍?