### PR TITLE
Analytics Update

### DIFF
--- a/Cloud Application Manager/Analytics/CloudApplicationManagerAnalyticsUI.md
+++ b/Cloud Application Manager/Analytics/CloudApplicationManagerAnalyticsUI.md
@@ -17,6 +17,14 @@ One of the following use cases must have occurred successfully:
 * The provider is enabled for [Cloud Optimization](https://www.ctl.io/knowledge-base/cloud-application-manager/cloud-optimization/#1)
 * The provider is no Optimized or Managed, but enabled for Analytics. (See below)
 
+### Important Information
+* After you activate Analytics for providers for which you pay the vendor directly, CenturyLink will read your Provider's charges in our calculation of Platform Advisory Support
+* For AWS, these are the scenarios where Analytics can provide cost and usage data: 1) accounts which are not members of AWS Organizations 2) accounts which are members of AWS organizations and the CAM admin has also set up an Analyzed provider for the Master Payer of that organization. 
+* In the second scenario above, CAM will read usage for the entire organization and apply that to Platform Advisory Support even if all the accounts in the organization have not all been associated to CAM Providers.
+* For AWS scenarios where Analytics does not see cost and usage data, it will still offer features including Inventory and Best Practices.
+
+
+
 #### Opting To Use Analytics for a Provider that is Not Optimized or Managed.
 
 ![Analytics Toggle in Provider](../../images/cloud-application-manager/CAM_COA_Analytics_Provider_Toggle.png)


### PR DESCRIPTION
### Important Information
* After you activate Analytics for providers for which you pay the vendor directly, CenturyLink will read your Provider's charges in our calculation of Platform Advisory Support
* For AWS, these are the scenarios where Analytics can provide cost and usage data: 1) accounts which are not members of AWS Organizations 2) accounts which are members of AWS organizations and the CAM admin has also set up an Analyzed provider for the Master Payer of that organization. 
* In the second scenario above, CAM will read usage for the entire organization and apply that to Platform Advisory Support even if all the accounts in the organization have not all been associated to CAM Providers.
* For AWS scenarios where Analytics does not see cost and usage data, it will still offer features including Inventory and Best Practices.