### PR TITLE
SBS Requires SFTP to Install Client Packages

### DIFF
--- a/Backup/simple-backup-service-faqs.md
+++ b/Backup/simple-backup-service-faqs.md
@@ -38,7 +38,18 @@ A: SSH for Root is required to allow the blueprint to initially install the back
   up-uc1.backup.ctl.io
   up-gb3.backup.ctl.io
   ```
+SBS Requires SFTP to Install Client Packages. Sftp service should be enabled on Linux Servers.
 
+   - To Enable sftp service on LInux Servers, 
+
+1. Edit SSH configuration file /etc/ssh/sshd_config and add the below line
+  ```
+Subsystem sftp /usr/libexec/openssh/sftp-server
+  ```
+2. save the file and restart sftp service to the changes take effect.
+  ```
+service sshd restart
+  ```
 **Q: What operating systems are supported?**
 
 A: If the server is using one of the [platform-supported operating systems](../Support/supported-operating-systems.md), then SBS may be installed. **NOTE:** Exceptions to this are listed below.


### PR DESCRIPTION
The below content added to the first Question in the KB. 

SBS Requires SFTP to Install Client Packages. Sftp service should be enabled on Linux Servers.

   - To Enable sftp service on LInux Servers, 

1. Edit SSH configuration file /etc/ssh/sshd_config and add the below line
  ```
Subsystem sftp /usr/libexec/openssh/sftp-server
  ```
2. save the file and restart sftp service to the changes take effect.
  ```
service sshd restart