### PR TITLE
Update Convert-Linux-to-repository-VMware-Tools.md

### DIFF
--- a/Servers/Convert-Linux-to-repository-VMware-Tools.md
+++ b/Servers/Convert-Linux-to-repository-VMware-Tools.md
@@ -29,12 +29,10 @@ Import the following keys
 
 **RHEL / CentOS:**
 
-`rpm --import http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub`
 `rpm --import http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub`
 
 **Ubuntu:**
 
-`wget http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub -O - | apt-key add -`
 `wget http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub -O - | apt-key add -`
 
 **Create the config file for the new repository:**


### PR DESCRIPTION
Removed VMWARE-PACKAGING-GPG-DSA-KEY.pub from this KB as this pub file not existing in http://packages.vmware.com/tools/keys/ location. 

http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub` file required only for Legacy open- vm-tools version lower than 9.10 for it is located in https://packages.vmware.com/tools/legacykeys/ location