### PR TITLE
Update cloud-server-alerting-faq.md

### DIFF
--- a/Servers/cloud-server-alerting-faq.md
+++ b/Servers/cloud-server-alerting-faq.md
@@ -54,6 +54,6 @@ The server page itself also shows the alert details. You can see both the curren
 
 **Q: How do alert webhooks work?**
 
-**A:** [Webhooks](https://t3n.zendesk.com/entries/22916235-Webhooks-FAQ") are a powerful way to build a more event-driven relationship with your cloud environment. Users of webhooks can integrate internal systems with the resources running in the cloud. Alerts are now available as webhooks! Whenever an alert fires, the Lumen Cloud platform sends out a JSON-encoded message to a web address specified by the user. These JSON messages include the name of alert, account name, server name, and threshold violation details. Users can choose to also receive webhook events for alerts raised in any sub accounts.
+**A:** Webhooks are a powerful way to build a more event-driven relationship with your cloud environment. Users of webhooks can integrate internal systems with the resources running in the cloud. Alerts are now available as webhooks! Whenever an alert fires, the Lumen Cloud platform sends out a JSON-encoded message to a web address specified by the user. These JSON messages include the name of alert, account name, server name, and threshold violation details. Users can choose to also receive webhook events for alerts raised in any sub accounts.
 
 ![monitoringfaq05](https://t3n.zendesk.com/attachments/token/jtiu0cckldrrzll/?name=monitoringfaq05.png)


### PR DESCRIPTION
In the Below Question section, the answer start with "Webhooks" word is enabled with Hyperlink (https://t3n.zendesk.com/entries/22916235-Webhooks-FAQ) which is not relevant here, and the linked URL is our internal link, and not available now.
 
**Q: How do alert webhooks work?**
**A:** [Webhooks](https://t3n.zendesk.com/entries/22916235-Webhooks-FAQ") are a powerful way to build a more event-driven relationship with your cloud environment.

Modification requested to remov the linked URL 