### PR TITLE
Scrubbing proprietary and sensitive details from the Edge bare betal …

### DIFF
--- a/Edge Computing Solutions/Getting Started/bare-metal-data-destruction-process.md
+++ b/Edge Computing Solutions/Getting Started/bare-metal-data-destruction-process.md
@@ -9,15 +9,12 @@
 
 ### Description
 
-This article applies specifically to the Edge Bare Metal Dell C6420 systems, and explains how we treat any data left on the system when it is returned.
+This article applies specifically to the Edge Bare Metal systems, and explains how we treat any data left on the system when it is returned.
 
 ### Details
 
-When a system is released, it is powered off and the Dell Cryptographic Erase command is applied to all of the Physical storage (SSD, NVMe), via Dell's Redfish API [2]. In addition, the iDRAC is factory reset and the system is reconfigured before being put back into service.
+All local server storage is encrypted on Bare Metal hardware. When a system is released by a customer, it is powered off and a cryptographic erase is performed on all of the Physical storage (SSD, NVMe).  When the cryptographic erase is triggered a new key is generated, thus none of the data is recoverable, even by exotic forensic techniques. Finally, the server hardware controller is factory reset and the system hardware is reconfigured before being put back into service.
 
-To summarize [1], all of the provided storage is automatically encrypted with a key known only to the Dell storage controller hardware. When the Cryptographic erase is triggered, the key is replaced with a new key. Thus none of the data is recoverable, even by exotic forensic techniques.
+Reference:
 
-References:
-
-1.  https://downloads.dell.com/manuals/common/dell-emc-system-erase-poweredge-idrac9.pdf
-2.  https://github.com/dell/iDRAC-Redfish-Scripting.git
+1. https://csrc.nist.gov/glossary/term/cryptographic_erase#:~:text=Definition(s)%3A,the%20decrypted%20Target%20Data%20infeasible.


### PR DESCRIPTION
…data destruction KB

1. Removed all information considered proprietary according to the Infrastructure Disclosure Sensitivity policy. 
https://www.ctl.io/knowledge-base/support/lumen-cloud-infrastructure-disclosure-confidentiality/
2.  Edited text for clarity. 
3.  Updated reference link to the US government Special Publication description for Cryptographic Erase.