### PR TITLE
Removed Runner

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,6 @@
     "Network",
     "Partners",
     "Release Notes",
-    "Runner",
     "Security",
     "Servers",
     "Service Tasks",


### PR DESCRIPTION
Runner was deprecated in 2020 and is no longer available.