### PR TITLE
Removed reference to Runner

### DIFF
--- a/Servers/creating-and-managing-server-snapshots.md
+++ b/Servers/creating-and-managing-server-snapshots.md
@@ -53,8 +53,6 @@ Customers can delete a snapshot by selecting the red X next to the snapshot name
 
 ### Scheduling Snapshots
 1. One-time snapshots can be configured as a [Scheduled Task](creating-a-scheduled-task.md)
-2. There are cases where a customer will benefit from taking or reverting snapshots of a server or group on a regular basis. Our [Runner Service](../Runner/getting-started-with-runner.md) provides the ability to schedule repeating snapshot events, there is an existing published Runner Snapshot Job.
-
 
 ### Summary
 The basic points to remember about snapshots:

--- a/Servers/creating-and-managing-server-snapshots.md
+++ b/Servers/creating-and-managing-server-snapshots.md
@@ -1,7 +1,7 @@
 {{{
   "title": "Creating and Managing Server Snapshots",
-  "date": "9-12-2017",
-  "author": "Chris Little",
+  "date": "11-3-2021",
+  "author": "Jeremy Peters",
   "attachments": [],
   "contentIsHTML": false
 }}}


### PR DESCRIPTION
Runner was deprecated in 2020 and is no longer available. Removed references to using Runner to schedule snapshots.